### PR TITLE
render doi for posts when one is provided.

### DIFF
--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -26,4 +26,15 @@
       {% endif %}
     {% endfor %}
   </span>
+  {% if page.doi %}
+    <p>
+      {% comment %}
+        If the post includes a doi in the header, then this is shown with
+        the metadata of the page.
+      {% endcomment %}
+      DOI: <a class="page-doi" href="https://doi.org/{{ page.doi }}">
+        {{ page.doi }}
+      </a>
+    </p>
+  {% endif %}
 </div>

--- a/_posts/2024-04-15-blog.md
+++ b/_posts/2024-04-15-blog.md
@@ -4,6 +4,7 @@ title: "Missing data and PCA"
 subtitle: "How little is too little?"
 authors:
  - Thiseas C. Lamnidis
+doi: 10.5281/zenodo.11185595
 categories: Blog
 tag: Blog
 ---


### PR DESCRIPTION
This PR adds rendering of DOIs together with the other post metadata (date and category) for posts, when  a doi is provided in the post header. 

It also adds a DOI for the first published blog.