### PR TITLE
HAAM-Tasting/HAAM-Radio fixes

### DIFF
--- a/_posts/2024-03-01-event.md
+++ b/_posts/2024-03-01-event.md
@@ -3,7 +3,7 @@ layout: post
 title: "HAAM-Tasting #1 - March 2024: Eurasian population demography and social organisation of the past"
 subtitle: "Now formally named HAAM-Radio"
 categories: Events
-tags: HAAM-Tasting
+tags: HAAM-Radio
 ---
 
 The inaugural HAAM-Tasting Webinar will be taking place online on the 20th of March, 2024 at 9.00 to 13.00 CET!

--- a/_posts/2024-03-01-event.md
+++ b/_posts/2024-03-01-event.md
@@ -1,11 +1,12 @@
 ---
 layout: post
-title: "HAAM-Radio #1 - March 2024: Eurasian population demography and social organisation of the past"
+title: "HAAM-Tasting #1 - March 2024: Eurasian population demography and social organisation of the past"
+subtitle: "Now formally named HAAM-Radio"
 categories: Events
-tags: HAAM-Radio
+tags: HAAM-Tasting
 ---
 
-The inaugural HAAM-Radio Webinar will be taking place online on the 20th of March, 2024 at 9.00 to 13.00 CET!
+The inaugural HAAM-Tasting Webinar will be taking place online on the 20th of March, 2024 at 9.00 to 13.00 CET!
 Our first ever webinar will focus on Eurasian population demography and social organisation of the past.
 
 We are delighted to announce the two invited speakers:

--- a/projects/haam_radio.md
+++ b/projects/haam_radio.md
@@ -8,7 +8,7 @@ Coordinators: [Tina Saupe](mailto:tina.saupe@ebc.uu.se) and [Xavier Roca-Rada](m
 
 For up-to-date information follow us on X at [@haam_community](https://twitter.com/HAAM_community) and use the [#HAAM-Radio](https://twitter.com/hashtag/HAAM-Radio). 
 
-The HAAM-Radio Webinar series is organised by members of the HAAM-community. We’re an international, open, and engaging working group. We focus on giving (early career) researchers the opportunity to present their research to a wider audience outside of the usual conference environments, and promoting equal representation within the field of ancient human DNA research.
+The HAAM-Radio Webinar series (formerly known as HAAM-Tasting) is organised by members of the HAAM-community. We’re an international, open, and engaging working group. We focus on giving (early career) researchers the opportunity to present their research to a wider audience outside of the usual conference environments, and promoting equal representation within the field of ancient human DNA research.
 
 Each webinar focuses on open research questions of one particular geographical region, time period and is planned to consist of two parts:
 - The first part are invited speakers introducing the theme of the current webinar and who have accepted to present their research to community members as well as others interested to get an insight into our ongoing research projects of the human past.


### PR DESCRIPTION
-- HAAM-radio project page references that it was formerly known as HAAM-Tasting
-- "HAAM-Radio º1" event page is back to "HAAM-Tasting º1", with a subtitle mentioning that it changed the name.