### PR TITLE
Update back-page links and logic.

### DIFF
--- a/_includes/back-link.html
+++ b/_includes/back-link.html
@@ -1,6 +1,73 @@
-{% assign back_page = site.pages | find: "name", page.back_page %}
-{% if back_page != null %}
+{% assign is_projects_page = false %}
+{% if page.url == '/projects/' or page.url == '/projects' or page.permalink == '/projects/' or page.url contains '/projects/' or page.path contains 'projects/' or page.category == 'projects' or page.categories contains 'projects' %}
+  {% assign is_projects_page = true %}
+{% endif %}
+
+{% if is_projects_page %}
+  {% assign back_page = site.pages | where: "name", "projects.md" | first %}
+  {% unless back_page %}
+    {% assign back_page = site.pages | where: "name", "projects.html" | first %}
+  {% endunless %}
+
+  {% unless back_page %}
+    {% assign back_page = site.pages | where: "name", "index.html" | first %}
+  {% endunless %}
+{% elsif page.layout == "post" %}
+  <!-- First, check if the page has a specified back page -->
+  {% if page.back_page %}
+    {% assign back_page = site.pages | where: "name", page.back_page | first %}
+  {% else %}
+    <!-- If no specific back page is specified, try to find a category page -->
+    {% assign back_page = false %}
+    {% assign page_category = page.categories | first | default: page.category %}
+    {% if page_category %}
+      <!-- If a category page exists, use it as the back page -->
+      {% for node in site.pages %}
+        {% assign node_category = node.category | default: node.title %}
+        {% if node.layout == "category" and node_category == page_category %}
+          {% assign back_page = node %}
+          {% break %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {% unless back_page %}
+      <!-- If neither a specific back page nor a category page is found, use the index page -->
+      {% assign back_page = site.pages | where: "name", "index.html" | first %}
+    {% endunless %}
+  {% endif %}
+{% endif %}
+
+{% if back_page %}
+  <!-- Only create back link if the current page is not the same as the back page -->
+  {% assign current_url = page.url | default: '' | replace: '/index.html', '' %}
+  {% assign back_url = back_page.url | default: '' | replace: '/index.html', '' %}
+
+  <!-- To avoid weird redirects, remove trailing slashes, only if the URL is longer than 1 character -->
+  {% assign current_url_length = current_url | size %}
+  {% if current_url_length > 1 %}
+    {% assign current_last_char = current_url | slice: -1, 1 %}
+    {% if current_last_char == '/' %}
+      {% assign current_cutoff = current_url_length | minus: 1 %}
+      {% assign current_url = current_url | slice: 0, current_cutoff %}
+    {% endif %}
+  {% endif %}
+
+  <!-- To avoid weird redirects, remove trailing slashes, only if the URL is longer than 1 character -->
+  {% assign back_url_length = back_url | size %}
+  {% if back_url_length > 1 %}
+    {% assign back_last_char = back_url | slice: -1, 1 %}
+    {% if back_last_char == '/' %}
+      {% assign back_cutoff = back_url_length | minus: 1 %}
+      {% assign back_url = back_url | slice: 0, back_cutoff %}
+    {% endif %}
+  {% endif %}
+
+  <!-- Now we can actually compare the strings and create the back link if they are different -->
+  {% if current_url != back_url %}
+    <!-- Render back arrow -->
     <p class="back-link">
-    <a href="{{ back_page.url | relative_url }}"><span class="back-arrow icon">{% include svg/back-arrow.svg %}</span>{{ back_page.short_title | default: back_page.title }}</a>
+      <a href="{{ back_page.url | relative_url }}"><span class="back-arrow icon">{% include svg/back-arrow.svg %}</span>{{ back_page.short_title | default: back_page.title }}</a>
     </p>
+  {% endif %}
 {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,9 +3,7 @@ layout: default
 ---
 
 <header style="margin-bottom: 1.5rem;">
-
   {% include back-link.html %}
-
   <h1 class="page-title">{{ page.title }}</h1>
 
   {% if page.page_logo %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,6 +3,7 @@ layout: default
 ---
 
 <header>
+  {% include back-link.html %}
   <h1 class="post-title">{{ page.title }}</h1>
   {% if page.subtitle %}
   <h2 class="page-subtitle">{{ page.subtitle }}</h2>
@@ -18,4 +19,5 @@ layout: default
 
   <!-- {% include comments.html %} -->
   {% include related_posts.html %}
+  {% include back-link.html %}
 </div>

--- a/_posts/2024-04-15-blog.md
+++ b/_posts/2024-04-15-blog.md
@@ -6,7 +6,7 @@ authors:
  - Thiseas C. Lamnidis
 doi: 10.5281/zenodo.11185595
 categories: Blog
-tag: Blog
+tags: Blog
 ---
 
 _by [Thiseas C. Lamnidis](https://www.eva.mpg.de/archaeogenetics/staff/thiseas-christos-lamnidis/)_


### PR DESCRIPTION
This PR adds back links at the top and bottom of posts linking back to the post's category.
They also add these arrows to project pages, linking back to the projects overview page.

The specific logic of the back-links checks if a `back_page` attribute was specified for a post, if not uses the category of the post. If that is also missing, then it uses `index.md`, i.e. the landing page.

Inspired by @nicksgoodusername post on Element.

The PR also fixes a minor typo in the tags for the blog post (oops). 